### PR TITLE
Fix fund raises to use dedicated table instead of VCs

### DIFF
--- a/client/pages/CreateFundRaise.tsx
+++ b/client/pages/CreateFundRaise.tsx
@@ -68,7 +68,7 @@ function generateStepOptions(start: number, end: number, step: number): string[]
   return result;
 }
 
-const FUND_MN_OPTIONS = generateStepOptions(0.05, 9.95, 0.05);
+const FUND_MN_OPTIONS = generateStepOptions(0.05, 10, 0.05);
 const VALUATION_MN_OPTIONS = ["0.50", ...generateStepOptions(1, 100, 1)];
 
 export default function CreateFundRaise() {

--- a/client/pages/CreateFundRaise.tsx
+++ b/client/pages/CreateFundRaise.tsx
@@ -69,6 +69,7 @@ function generateStepOptions(start: number, end: number, step: number): string[]
 }
 
 const FUND_MN_OPTIONS = generateStepOptions(0.05, 10, 0.05);
+const VALUATION_MN_OPTIONS = ["0.50", ...generateStepOptions(1, 100, 1)];
 
 export default function CreateFundRaise() {
   const navigate = useNavigate();
@@ -76,6 +77,7 @@ export default function CreateFundRaise() {
   const queryClient = useQueryClient();
   const [fundMnOpen, setFundMnOpen] = useState(false);
   const [fundMnOpenMain, setFundMnOpenMain] = useState(false);
+  const [valuationOpen, setValuationOpen] = useState(false);
 
   const [form, setForm] = useState({
     vc_investor: "",
@@ -392,17 +394,35 @@ export default function CreateFundRaise() {
 
                 <div>
                   <Label>Valuation $ Mn</Label>
-                  <div className="relative">
-                    <DollarSign className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                    <Input
-                      placeholder="e.g. 100"
-                      className="pl-10"
-                      value={form.valuation_mn}
-                      onChange={(e) =>
-                        handleChange("valuation_mn", e.target.value)
-                      }
-                    />
-                  </div>
+                  <Popover open={valuationOpen} onOpenChange={setValuationOpen}>
+                    <PopoverTrigger asChild>
+                      <Button variant="outline" className="w-full justify-between">
+                        {form.valuation_mn || "Select valuation"}
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent side="bottom" align="start" avoidCollisions={false} className="p-0 w-[200px]">
+                      <Command>
+                        <CommandInput placeholder="Search valuation..." />
+                        <CommandList>
+                          <CommandEmpty>No valuations found.</CommandEmpty>
+                          <CommandGroup>
+                            {VALUATION_MN_OPTIONS.map((v) => (
+                              <CommandItem
+                                key={v}
+                                value={v}
+                                onSelect={(val) => {
+                                  handleChange("valuation_mn", val);
+                                  setValuationOpen(false);
+                                }}
+                              >
+                                {v}
+                              </CommandItem>
+                            ))}
+                          </CommandGroup>
+                        </CommandList>
+                      </Command>
+                    </PopoverContent>
+                  </Popover>
                 </div>
               </div>
 

--- a/client/pages/CreateFundRaise.tsx
+++ b/client/pages/CreateFundRaise.tsx
@@ -68,7 +68,7 @@ function generateStepOptions(start: number, end: number, step: number): string[]
   return result;
 }
 
-const FUND_MN_OPTIONS = generateStepOptions(0.05, 10, 0.05);
+const FUND_MN_OPTIONS = generateStepOptions(0.05, 9.95, 0.05);
 const VALUATION_MN_OPTIONS = ["0.50", ...generateStepOptions(1, 100, 1)];
 
 export default function CreateFundRaise() {

--- a/client/pages/CreateFundRaise.tsx
+++ b/client/pages/CreateFundRaise.tsx
@@ -56,28 +56,26 @@ const INVESTOR_STATUS_OPTIONS = [
   { value: "Future Potential", label: "Future Potential" },
 ];
 
-const FUND_MN_OPTIONS = [
-  "0.05",
-  "0.10",
-  "0.25",
-  "0.50",
-  "1.00",
-  "2.00",
-  "3.00",
-  "4.00",
-  "5.00",
-  "6.00",
-  "7.00",
-  "8.00",
-  "9.00",
-  "10.00",
-];
+function generateStepOptions(start: number, end: number, step: number): string[] {
+  const result: string[] = [];
+  const scale = 100; // to avoid floating-point errors
+  const startScaled = Math.round(start * scale);
+  const endScaled = Math.round(end * scale);
+  const stepScaled = Math.round(step * scale);
+  for (let v = startScaled; v <= endScaled; v += stepScaled) {
+    result.push((v / scale).toFixed(2));
+  }
+  return result;
+}
+
+const FUND_MN_OPTIONS = generateStepOptions(0.05, 10, 0.05);
 
 export default function CreateFundRaise() {
   const navigate = useNavigate();
   const { user } = useAuth();
   const queryClient = useQueryClient();
   const [fundMnOpen, setFundMnOpen] = useState(false);
+  const [fundMnOpenMain, setFundMnOpenMain] = useState(false);
 
   const [form, setForm] = useState({
     vc_investor: "",
@@ -361,17 +359,35 @@ export default function CreateFundRaise() {
 
                 <div>
                   <Label>Total Fund Raise $ Mn</Label>
-                  <div className="relative">
-                    <DollarSign className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                    <Input
-                      placeholder="e.g. 10"
-                      className="pl-10"
-                      value={form.total_raise_mn}
-                      onChange={(e) =>
-                        handleChange("total_raise_mn", e.target.value)
-                      }
-                    />
-                  </div>
+                  <Popover open={fundMnOpenMain} onOpenChange={setFundMnOpenMain}>
+                    <PopoverTrigger asChild>
+                      <Button variant="outline" className="w-full justify-between">
+                        {form.total_raise_mn || "Select amount"}
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent side="bottom" align="start" avoidCollisions={false} className="p-0 w-[200px]">
+                      <Command>
+                        <CommandInput placeholder="Search amount..." />
+                        <CommandList>
+                          <CommandEmpty>No amounts found.</CommandEmpty>
+                          <CommandGroup>
+                            {FUND_MN_OPTIONS.map((v) => (
+                              <CommandItem
+                                key={v}
+                                value={v}
+                                onSelect={(val) => {
+                                  handleChange("total_raise_mn", val);
+                                  setFundMnOpenMain(false);
+                                }}
+                              >
+                                {v}
+                              </CommandItem>
+                            ))}
+                          </CommandGroup>
+                        </CommandList>
+                      </Command>
+                    </PopoverContent>
+                  </Popover>
                 </div>
 
                 <div>

--- a/client/pages/CreateFundRaise.tsx
+++ b/client/pages/CreateFundRaise.tsx
@@ -22,6 +22,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
 import { ArrowLeft, Plus, Calendar, DollarSign, Building } from "lucide-react";
 
 const STATUS_OPTIONS = [
@@ -75,6 +77,7 @@ export default function CreateFundRaise() {
   const navigate = useNavigate();
   const { user } = useAuth();
   const queryClient = useQueryClient();
+  const [fundMnOpen, setFundMnOpen] = useState(false);
 
   const [form, setForm] = useState({
     vc_investor: "",
@@ -408,21 +411,35 @@ export default function CreateFundRaise() {
             <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
                 <Label>Fund $ Mn</Label>
-                <Select
-                  value={form.total_raise_mn}
-                  onValueChange={(v) => handleChange("total_raise_mn", v)}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select amount" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {FUND_MN_OPTIONS.map((v) => (
-                      <SelectItem key={v} value={v}>
-                        {v}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <Popover open={fundMnOpen} onOpenChange={setFundMnOpen}>
+                  <PopoverTrigger asChild>
+                    <Button variant="outline" className="w-full justify-between">
+                      {form.total_raise_mn || "Select amount"}
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent side="bottom" align="start" avoidCollisions={false} className="p-0 w-[200px]">
+                    <Command>
+                      <CommandInput placeholder="Search amount..." />
+                      <CommandList>
+                        <CommandEmpty>No amounts found.</CommandEmpty>
+                        <CommandGroup>
+                          {FUND_MN_OPTIONS.map((v) => (
+                            <CommandItem
+                              key={v}
+                              value={v}
+                              onSelect={(val) => {
+                                handleChange("total_raise_mn", val);
+                                setFundMnOpen(false);
+                              }}
+                            >
+                              {v}
+                            </CommandItem>
+                          ))}
+                        </CommandGroup>
+                      </CommandList>
+                    </Command>
+                  </PopoverContent>
+                </Popover>
               </div>
               <div>
                 <Label>Investor Status</Label>

--- a/client/pages/CreateFundRaise.tsx
+++ b/client/pages/CreateFundRaise.tsx
@@ -22,8 +22,19 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
 import { ArrowLeft, Plus, Calendar, DollarSign, Building } from "lucide-react";
 
 const STATUS_OPTIONS = [
@@ -56,7 +67,11 @@ const INVESTOR_STATUS_OPTIONS = [
   { value: "Future Potential", label: "Future Potential" },
 ];
 
-function generateStepOptions(start: number, end: number, step: number): string[] {
+function generateStepOptions(
+  start: number,
+  end: number,
+  step: number,
+): string[] {
   const result: string[] = [];
   const scale = 100; // to avoid floating-point errors
   const startScaled = Math.round(start * scale);
@@ -361,13 +376,25 @@ export default function CreateFundRaise() {
 
                 <div>
                   <Label>Total Fund Raise $ Mn</Label>
-                  <Popover open={fundMnOpenMain} onOpenChange={setFundMnOpenMain}>
+                  <Popover
+                    open={fundMnOpenMain}
+                    onOpenChange={setFundMnOpenMain}
+                  >
                     <PopoverTrigger asChild>
-                      <Button variant="outline" className="w-full justify-between">
+                      <Button
+                        variant="outline"
+                        className="w-full justify-between"
+                      >
                         {form.total_raise_mn || "Select amount"}
                       </Button>
                     </PopoverTrigger>
-                    <PopoverContent side="bottom" align="start" avoidCollisions={true} collisionPadding={8} className="p-0 w-[240px] max-h-[min(50vh,320px)] overflow-auto">
+                    <PopoverContent
+                      side="bottom"
+                      align="start"
+                      avoidCollisions={true}
+                      collisionPadding={8}
+                      className="p-0 w-[240px] max-h-[min(50vh,320px)] overflow-auto"
+                    >
                       <Command>
                         <CommandInput placeholder="Search amount..." />
                         <CommandList>
@@ -396,11 +423,20 @@ export default function CreateFundRaise() {
                   <Label>Valuation $ Mn</Label>
                   <Popover open={valuationOpen} onOpenChange={setValuationOpen}>
                     <PopoverTrigger asChild>
-                      <Button variant="outline" className="w-full justify-between">
+                      <Button
+                        variant="outline"
+                        className="w-full justify-between"
+                      >
                         {form.valuation_mn || "Select valuation"}
                       </Button>
                     </PopoverTrigger>
-                    <PopoverContent side="bottom" align="start" avoidCollisions={true} collisionPadding={8} className="p-0 w-[240px] max-h-[min(50vh,320px)] overflow-auto">
+                    <PopoverContent
+                      side="bottom"
+                      align="start"
+                      avoidCollisions={true}
+                      collisionPadding={8}
+                      className="p-0 w-[240px] max-h-[min(50vh,320px)] overflow-auto"
+                    >
                       <Command>
                         <CommandInput placeholder="Search valuation..." />
                         <CommandList>
@@ -449,11 +485,20 @@ export default function CreateFundRaise() {
                 <Label>Fund $ Mn</Label>
                 <Popover open={fundMnOpen} onOpenChange={setFundMnOpen}>
                   <PopoverTrigger asChild>
-                    <Button variant="outline" className="w-full justify-between">
+                    <Button
+                      variant="outline"
+                      className="w-full justify-between"
+                    >
                       {form.total_raise_mn || "Select amount"}
                     </Button>
                   </PopoverTrigger>
-                  <PopoverContent side="bottom" align="start" avoidCollisions={true} collisionPadding={8} className="p-0 w-[240px] max-h-[min(50vh,320px)] overflow-auto">
+                  <PopoverContent
+                    side="bottom"
+                    align="start"
+                    avoidCollisions={true}
+                    collisionPadding={8}
+                    className="p-0 w-[240px] max-h-[min(50vh,320px)] overflow-auto"
+                  >
                     <Command>
                       <CommandInput placeholder="Search amount..." />
                       <CommandList>

--- a/client/pages/CreateFundRaise.tsx
+++ b/client/pages/CreateFundRaise.tsx
@@ -54,6 +54,23 @@ const INVESTOR_STATUS_OPTIONS = [
   { value: "Future Potential", label: "Future Potential" },
 ];
 
+const FUND_MN_OPTIONS = [
+  "0.05",
+  "0.10",
+  "0.25",
+  "0.50",
+  "1.00",
+  "2.00",
+  "3.00",
+  "4.00",
+  "5.00",
+  "6.00",
+  "7.00",
+  "8.00",
+  "9.00",
+  "10.00",
+];
+
 export default function CreateFundRaise() {
   const navigate = useNavigate();
   const { user } = useAuth();

--- a/client/pages/CreateFundRaise.tsx
+++ b/client/pages/CreateFundRaise.tsx
@@ -407,18 +407,18 @@ export default function CreateFundRaise() {
             </CardHeader>
             <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <Label>Status</Label>
+                <Label>Fund $ Mn</Label>
                 <Select
-                  value={form.status}
-                  onValueChange={(v) => handleChange("status", v)}
+                  value={form.total_raise_mn}
+                  onValueChange={(v) => handleChange("total_raise_mn", v)}
                 >
                   <SelectTrigger>
-                    <SelectValue placeholder="Select Status" />
+                    <SelectValue placeholder="Select amount" />
                   </SelectTrigger>
                   <SelectContent>
-                    {STATUS_OPTIONS.map((s) => (
-                      <SelectItem key={s.value} value={s.value}>
-                        {s.label}
+                    {FUND_MN_OPTIONS.map((v) => (
+                      <SelectItem key={v} value={v}>
+                        {v}
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/client/pages/CreateFundRaise.tsx
+++ b/client/pages/CreateFundRaise.tsx
@@ -367,7 +367,7 @@ export default function CreateFundRaise() {
                         {form.total_raise_mn || "Select amount"}
                       </Button>
                     </PopoverTrigger>
-                    <PopoverContent side="bottom" align="start" avoidCollisions={false} className="p-0 w-[200px]">
+                    <PopoverContent side="bottom" align="start" avoidCollisions={true} collisionPadding={8} className="p-0 w-[240px] max-h-[min(50vh,320px)] overflow-auto">
                       <Command>
                         <CommandInput placeholder="Search amount..." />
                         <CommandList>
@@ -400,7 +400,7 @@ export default function CreateFundRaise() {
                         {form.valuation_mn || "Select valuation"}
                       </Button>
                     </PopoverTrigger>
-                    <PopoverContent side="bottom" align="start" avoidCollisions={false} className="p-0 w-[200px]">
+                    <PopoverContent side="bottom" align="start" avoidCollisions={true} collisionPadding={8} className="p-0 w-[240px] max-h-[min(50vh,320px)] overflow-auto">
                       <Command>
                         <CommandInput placeholder="Search valuation..." />
                         <CommandList>
@@ -453,7 +453,7 @@ export default function CreateFundRaise() {
                       {form.total_raise_mn || "Select amount"}
                     </Button>
                   </PopoverTrigger>
-                  <PopoverContent side="bottom" align="start" avoidCollisions={false} className="p-0 w-[200px]">
+                  <PopoverContent side="bottom" align="start" avoidCollisions={true} collisionPadding={8} className="p-0 w-[240px] max-h-[min(50vh,320px)] overflow-auto">
                     <Command>
                       <CommandInput placeholder="Search amount..." />
                       <CommandList>

--- a/client/pages/CreateFundRaise.tsx
+++ b/client/pages/CreateFundRaise.tsx
@@ -155,7 +155,10 @@ export default function CreateFundRaise() {
       const result = await createMutation.mutateAsync(payload);
       newId = result?.data?.id || result?.id;
     } catch (e) {
-      console.warn("VC creation failed, proceeding with fund_raises insert only:", e);
+      console.warn(
+        "VC creation failed, proceeding with fund_raises insert only:",
+        e,
+      );
     }
 
     try {

--- a/client/pages/CreateVC.tsx
+++ b/client/pages/CreateVC.tsx
@@ -241,6 +241,62 @@ const MIN_CHQ_SIZE_OPTIONS = [
   "10.00",
 ];
 
+const MAX_CHQ_SIZE_OPTIONS = [
+  "0.10",
+  "0.25",
+  "0.50",
+  "1.00",
+  "2.00",
+  "3.00",
+  "4.00",
+  "5.00",
+  "6.00",
+  "7.00",
+  "8.00",
+  "9.00",
+  "10.00",
+  "11.00",
+  "12.00",
+  "13.00",
+  "14.00",
+  "15.00",
+  "16.00",
+  "17.00",
+  "18.00",
+  "19.00",
+  "20.00",
+  "21.00",
+  "22.00",
+  "23.00",
+  "24.00",
+  "25.00",
+  "26.00",
+  "27.00",
+  "28.00",
+  "29.00",
+  "30.00",
+  "31.00",
+  "32.00",
+  "33.00",
+  "34.00",
+  "35.00",
+  "36.00",
+  "37.00",
+  "38.00",
+  "39.00",
+  "40.00",
+  "41.00",
+  "42.00",
+  "43.00",
+  "44.00",
+  "45.00",
+  "46.00",
+  "47.00",
+  "48.00",
+  "49.00",
+  "50.00",
+];
+
 const TABS = [
   { value: "lead", label: "Investors Info", icon: "📋" },
   { value: "investor", label: "Investors Contact Info", icon: "🏢" },
@@ -1703,14 +1759,53 @@ export default function CreateVC() {
 
                   <div>
                     <Label htmlFor="maximum_size">Max.Chq Size $ Mn</Label>
-                    <Input
-                      id="maximum_size"
-                      placeholder="e.g., 10"
-                      value={vcData.maximum_size}
-                      onChange={(e) =>
-                        handleInputChange("maximum_size", e.target.value)
-                      }
-                    />
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <Button
+                          variant="outline"
+                          role="combobox"
+                          aria-expanded={false}
+                          className="w-full justify-between"
+                        >
+                          {vcData.maximum_size || "Select amount"}
+                          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                        </Button>
+                      </PopoverTrigger>
+                      <PopoverContent
+                        side="bottom"
+                        align="start"
+                        avoidCollisions={false}
+                        className="w-[--radix-popover-trigger-width] p-0"
+                      >
+                        <Command>
+                          <CommandInput placeholder="Search amount..." />
+                          <CommandList>
+                            <CommandEmpty>No amounts found.</CommandEmpty>
+                            <CommandGroup>
+                              {MAX_CHQ_SIZE_OPTIONS.map((v) => (
+                                <CommandItem
+                                  key={v}
+                                  value={v}
+                                  onSelect={(val) => {
+                                    handleInputChange("maximum_size", val);
+                                  }}
+                                >
+                                  <Check
+                                    className={cn(
+                                      "mr-2 h-4 w-4",
+                                      vcData.maximum_size === v
+                                        ? "opacity-100"
+                                        : "opacity-0",
+                                    )}
+                                  />
+                                  {v}
+                                </CommandItem>
+                              ))}
+                            </CommandGroup>
+                          </CommandList>
+                        </Command>
+                      </PopoverContent>
+                    </Popover>
                   </div>
 
                   <div className="md:col-span-2">

--- a/client/pages/CreateVC.tsx
+++ b/client/pages/CreateVC.tsx
@@ -224,6 +224,23 @@ const CURRENCIES = [
   { value: "AED", label: "AED (د.إ)", symbol: "د.إ" },
 ];
 
+const MIN_CHQ_SIZE_OPTIONS = [
+  "0.05",
+  "0.10",
+  "0.25",
+  "0.50",
+  "1.00",
+  "2.00",
+  "3.00",
+  "4.00",
+  "5.00",
+  "6.00",
+  "7.00",
+  "8.00",
+  "9.00",
+  "10.00",
+];
+
 const TABS = [
   { value: "lead", label: "Investors Info", icon: "📋" },
   { value: "investor", label: "Investors Contact Info", icon: "🏢" },
@@ -1635,14 +1652,53 @@ export default function CreateVC() {
 
                   <div>
                     <Label htmlFor="minimum_size">Min.Chq Size $ Mn</Label>
-                    <Input
-                      id="minimum_size"
-                      placeholder="e.g., 1"
-                      value={vcData.minimum_size}
-                      onChange={(e) =>
-                        handleInputChange("minimum_size", e.target.value)
-                      }
-                    />
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <Button
+                          variant="outline"
+                          role="combobox"
+                          aria-expanded={false}
+                          className="w-full justify-between"
+                        >
+                          {vcData.minimum_size || "Select amount"}
+                          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                        </Button>
+                      </PopoverTrigger>
+                      <PopoverContent
+                        side="bottom"
+                        align="start"
+                        avoidCollisions={false}
+                        className="w-[--radix-popover-trigger-width] p-0"
+                      >
+                        <Command>
+                          <CommandInput placeholder="Search amount..." />
+                          <CommandList>
+                            <CommandEmpty>No amounts found.</CommandEmpty>
+                            <CommandGroup>
+                              {MIN_CHQ_SIZE_OPTIONS.map((v) => (
+                                <CommandItem
+                                  key={v}
+                                  value={v}
+                                  onSelect={(val) => {
+                                    handleInputChange("minimum_size", val);
+                                  }}
+                                >
+                                  <Check
+                                    className={cn(
+                                      "mr-2 h-4 w-4",
+                                      vcData.minimum_size === v
+                                        ? "opacity-100"
+                                        : "opacity-0",
+                                    )}
+                                  />
+                                  {v}
+                                </CommandItem>
+                              ))}
+                            </CommandGroup>
+                          </CommandList>
+                        </Command>
+                      </PopoverContent>
+                    </Popover>
                   </div>
 
                   <div>

--- a/client/pages/FundRaiseDashboard.tsx
+++ b/client/pages/FundRaiseDashboard.tsx
@@ -51,6 +51,12 @@ const statusColors: Record<string, string> = {
   completed: "bg-purple-100 text-purple-700",
 };
 
+const UI_STATUS_TO_INTERNAL: Record<string, string> = {
+  WIP: "in-progress",
+  Closed: "completed",
+  Dropped: "lost",
+};
+
 export default function FundRaiseDashboard() {
   const navigate = useNavigate();
   const { user } = useAuth();
@@ -119,6 +125,37 @@ export default function FundRaiseDashboard() {
     retry: false,
     staleTime: 60000,
   });
+
+  // Fetch Fund Raises list from dedicated table
+  const { data: fundRaises = [], isLoading: fundRaisesLoading, error: fundRaisesError } = useQuery({
+    queryKey: ["fund-raises"],
+    queryFn: async () => {
+      try {
+        const result = await apiClient.request("/fund-raises");
+        return Array.isArray(result) ? result : [];
+      } catch {
+        return [];
+      }
+    },
+    retry: false,
+    staleTime: 30000,
+  });
+
+  const filteredFundRaises = (fundRaises || [])
+    .filter((fr: any) => {
+      if (!searchTerm) return true;
+      const s = searchTerm.toLowerCase();
+      return (
+        (fr.investor_name || "").toLowerCase().includes(s) ||
+        (fr.reason || "").toLowerCase().includes(s) ||
+        (fr.round_stage || "").toLowerCase().includes(s)
+      );
+    })
+    .sort((a: any, b: any) => {
+      const aValue = a[sortBy] || "";
+      const bValue = b[sortBy] || "";
+      return sortOrder === "asc" ? (aValue > bValue ? 1 : -1) : aValue < bValue ? 1 : -1;
+    });
 
   const { data: vcProgressData = [], isLoading: progressLoading } = useQuery({
     queryKey: ["vc-progress"],
@@ -1181,28 +1218,37 @@ export default function FundRaiseDashboard() {
             <CardDescription>Recent entries</CardDescription>
           </CardHeader>
           <CardContent className="space-y-2">
-            {filteredVCs.map((vc: any) => (
-              <div
-                key={vc.id || vc.vc_id}
-                className="flex items-center justify-between p-3 bg-gray-50 rounded cursor-pointer hover:bg-gray-100"
-                onClick={() => vc?.id && navigate(`/fundraise/${vc.id}`)}
-                title="Open Fund Raise Overview"
-              >
-                <div className="flex items-center gap-3">
-                  <div className="font-medium text-gray-900">
-                    {vc.round_title || "Fund Raise"}
+            {fundRaisesError ? (
+              <div className="p-3 text-red-600">Failed to load fund raises</div>
+            ) : fundRaisesLoading ? (
+              <div className="p-3 text-gray-500">Loading...</div>
+            ) : (
+              filteredFundRaises.map((fr: any) => {
+                const internalStatus = fr.status || UI_STATUS_TO_INTERNAL[fr.ui_status || ""] || "in-progress";
+                return (
+                  <div
+                    key={fr.id}
+                    className="flex items-center justify-between p-3 bg-gray-50 rounded cursor-pointer hover:bg-gray-100"
+                    onClick={() => fr.vc_id && navigate(`/fundraise/${fr.vc_id}`)}
+                    title={fr.vc_id ? "Open Fund Raise Overview" : "VC not linked"}
+                  >
+                    <div className="flex items-center gap-3">
+                      <div className="font-medium text-gray-900">
+                        {fr.investor_name || "Fund Raise"}
+                      </div>
+                      <Badge className={statusColors[internalStatus] || ""}>
+                        {(fr.ui_status || internalStatus).toString().replace("-", " ")}
+                      </Badge>
+                    </div>
+                    <div className="text-right">
+                      <div className="text-sm text-gray-700">
+                        {fr.total_raise_mn ? `$${fr.total_raise_mn} Mn` : ""}
+                      </div>
+                    </div>
                   </div>
-                  <Badge className={statusColors[vc.status] || ""}>
-                    {(vc.status || "").replace("-", " ")}
-                  </Badge>
-                </div>
-                <div className="text-right">
-                  <div className="text-sm text-gray-700">
-                    {vc.investor_name || "N/A"}
-                  </div>
-                </div>
-              </div>
-            ))}
+                );
+              })
+            )}
           </CardContent>
         </Card>
       </div>

--- a/client/pages/FundRaiseDashboard.tsx
+++ b/client/pages/FundRaiseDashboard.tsx
@@ -127,7 +127,11 @@ export default function FundRaiseDashboard() {
   });
 
   // Fetch Fund Raises list from dedicated table
-  const { data: fundRaises = [], isLoading: fundRaisesLoading, error: fundRaisesError } = useQuery({
+  const {
+    data: fundRaises = [],
+    isLoading: fundRaisesLoading,
+    error: fundRaisesError,
+  } = useQuery({
     queryKey: ["fund-raises"],
     queryFn: async () => {
       try {
@@ -154,7 +158,13 @@ export default function FundRaiseDashboard() {
     .sort((a: any, b: any) => {
       const aValue = a[sortBy] || "";
       const bValue = b[sortBy] || "";
-      return sortOrder === "asc" ? (aValue > bValue ? 1 : -1) : aValue < bValue ? 1 : -1;
+      return sortOrder === "asc"
+        ? aValue > bValue
+          ? 1
+          : -1
+        : aValue < bValue
+          ? 1
+          : -1;
     });
 
   const { data: vcProgressData = [], isLoading: progressLoading } = useQuery({
@@ -1224,20 +1234,29 @@ export default function FundRaiseDashboard() {
               <div className="p-3 text-gray-500">Loading...</div>
             ) : (
               filteredFundRaises.map((fr: any) => {
-                const internalStatus = fr.status || UI_STATUS_TO_INTERNAL[fr.ui_status || ""] || "in-progress";
+                const internalStatus =
+                  fr.status ||
+                  UI_STATUS_TO_INTERNAL[fr.ui_status || ""] ||
+                  "in-progress";
                 return (
                   <div
                     key={fr.id}
                     className="flex items-center justify-between p-3 bg-gray-50 rounded cursor-pointer hover:bg-gray-100"
-                    onClick={() => fr.vc_id && navigate(`/fundraise/${fr.vc_id}`)}
-                    title={fr.vc_id ? "Open Fund Raise Overview" : "VC not linked"}
+                    onClick={() =>
+                      fr.vc_id && navigate(`/fundraise/${fr.vc_id}`)
+                    }
+                    title={
+                      fr.vc_id ? "Open Fund Raise Overview" : "VC not linked"
+                    }
                   >
                     <div className="flex items-center gap-3">
                       <div className="font-medium text-gray-900">
                         {fr.investor_name || "Fund Raise"}
                       </div>
                       <Badge className={statusColors[internalStatus] || ""}>
-                        {(fr.ui_status || internalStatus).toString().replace("-", " ")}
+                        {(fr.ui_status || internalStatus)
+                          .toString()
+                          .replace("-", " ")}
                       </Badge>
                     </div>
                     <div className="text-right">

--- a/client/pages/FundRaiseDetails.tsx
+++ b/client/pages/FundRaiseDetails.tsx
@@ -509,37 +509,55 @@ export default function FundRaiseDetails() {
                 </div>
                 <div>
                   <div className="space-y-3">
-                    <h4 className="font-medium text-gray-900">Funding Information</h4>
+                    <h4 className="font-medium text-gray-900">
+                      Funding Information
+                    </h4>
                     <div className="space-y-2">
                       <div>
-                        <span className="font-medium text-gray-600">Round Stage: </span>
-                        <Badge className={
-                          roundStageColors[
-                            vcData.round_stage as keyof typeof roundStageColors
-                          ]
-                        }>
+                        <span className="font-medium text-gray-600">
+                          Round Stage:{" "}
+                        </span>
+                        <Badge
+                          className={
+                            roundStageColors[
+                              vcData.round_stage as keyof typeof roundStageColors
+                            ]
+                          }
+                        >
                           {getRoundStageDisplay(vcData.round_stage)}
                         </Badge>
                       </div>
                       <div>
-                        <span className="font-medium text-gray-600">Round Size: </span>
-                        <span className="text-gray-900">{formatCurrency(
-                          vcData.round_size,
-                          vcData.billing_currency,
-                        ) || "TBD"}</span>
+                        <span className="font-medium text-gray-600">
+                          Round Size:{" "}
+                        </span>
+                        <span className="text-gray-900">
+                          {formatCurrency(
+                            vcData.round_size,
+                            vcData.billing_currency,
+                          ) || "TBD"}
+                        </span>
                       </div>
                       <div>
-                        <span className="font-medium text-gray-600">Valuation: </span>
-                        <span className="text-gray-900">{formatCurrency(
-                          vcData.valuation,
-                          vcData.billing_currency,
-                        ) || "TBD"}</span>
+                        <span className="font-medium text-gray-600">
+                          Valuation:{" "}
+                        </span>
+                        <span className="text-gray-900">
+                          {formatCurrency(
+                            vcData.valuation,
+                            vcData.billing_currency,
+                          ) || "TBD"}
+                        </span>
                       </div>
                     </div>
                     {vcData.round_description && (
                       <div className="mt-1">
-                        <span className="font-medium text-gray-600">Description: </span>
-                        <span className="text-gray-900">{vcData.round_description}</span>
+                        <span className="font-medium text-gray-600">
+                          Description:{" "}
+                        </span>
+                        <span className="text-gray-900">
+                          {vcData.round_description}
+                        </span>
                       </div>
                     )}
                   </div>

--- a/client/pages/FundRaiseDetails.tsx
+++ b/client/pages/FundRaiseDetails.tsx
@@ -507,64 +507,43 @@ export default function FundRaiseDetails() {
                     </div>
                   </div>
                 </div>
-              </div>
-
-              <Separator />
-              <div>
-                <h4 className="font-medium text-gray-900 mb-2">
-                  Funding Information
-                </h4>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                  <div className="space-y-2">
-                    <div>
-                      <span className="font-medium text-gray-600">
-                        Round Stage:{" "}
-                      </span>
-                      <Badge
-                        className={
+                <div>
+                  <div className="space-y-3">
+                    <h4 className="font-medium text-gray-900">Funding Information</h4>
+                    <div className="space-y-2">
+                      <div>
+                        <span className="font-medium text-gray-600">Round Stage: </span>
+                        <Badge className={
                           roundStageColors[
                             vcData.round_stage as keyof typeof roundStageColors
                           ]
-                        }
-                      >
-                        {getRoundStageDisplay(vcData.round_stage)}
-                      </Badge>
-                    </div>
-                    <div>
-                      <span className="font-medium text-gray-600">
-                        Round Size:{" "}
-                      </span>
-                      <span className="text-gray-900">
-                        {formatCurrency(
+                        }>
+                          {getRoundStageDisplay(vcData.round_stage)}
+                        </Badge>
+                      </div>
+                      <div>
+                        <span className="font-medium text-gray-600">Round Size: </span>
+                        <span className="text-gray-900">{formatCurrency(
                           vcData.round_size,
                           vcData.billing_currency,
-                        ) || "TBD"}
-                      </span>
-                    </div>
-                    <div>
-                      <span className="font-medium text-gray-600">
-                        Valuation:{" "}
-                      </span>
-                      <span className="text-gray-900">
-                        {formatCurrency(
+                        ) || "TBD"}</span>
+                      </div>
+                      <div>
+                        <span className="font-medium text-gray-600">Valuation: </span>
+                        <span className="text-gray-900">{formatCurrency(
                           vcData.valuation,
                           vcData.billing_currency,
-                        ) || "TBD"}
-                      </span>
+                        ) || "TBD"}</span>
+                      </div>
                     </div>
+                    {vcData.round_description && (
+                      <div className="mt-1">
+                        <span className="font-medium text-gray-600">Description: </span>
+                        <span className="text-gray-900">{vcData.round_description}</span>
+                      </div>
+                    )}
                   </div>
                 </div>
-
-                {vcData.round_description && (
-                  <div className="mt-3">
-                    <span className="font-medium text-gray-600">
-                      Description:{" "}
-                    </span>
-                    <span className="text-gray-900">
-                      {vcData.round_description}
-                    </span>
-                  </div>
-                )}
               </div>
 
               {vcData.notes && (

--- a/client/pages/FundRaiseDetails.tsx
+++ b/client/pages/FundRaiseDetails.tsx
@@ -507,41 +507,6 @@ export default function FundRaiseDetails() {
                     </div>
                   </div>
                 </div>
-                <div>
-                  <div className="space-y-3">
-                    <div className="flex items-center space-x-2">
-                      <User className="w-4 h-4 text-gray-400" />
-                      <span className="font-medium text-gray-600">
-                        Contact Person:
-                      </span>
-                      <span className="text-gray-900">
-                        {getPrimaryContact(vcData)?.contact_name ||
-                          "Not provided"}
-                      </span>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <Mail className="w-4 h-4 text-gray-400" />
-                      <span className="font-medium text-gray-600">Email:</span>
-                      {getPrimaryContact(vcData)?.email ? (
-                        <a
-                          href={`mailto:${getPrimaryContact(vcData)?.email}`}
-                          className="text-blue-600 hover:underline"
-                        >
-                          {getPrimaryContact(vcData)?.email}
-                        </a>
-                      ) : (
-                        <span className="text-gray-900">Not provided</span>
-                      )}
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <Phone className="w-4 h-4 text-gray-400" />
-                      <span className="font-medium text-gray-600">Phone:</span>
-                      <span className="text-gray-900">
-                        {getPrimaryContact(vcData)?.phone || "Not provided"}
-                      </span>
-                    </div>
-                  </div>
-                </div>
               </div>
 
               <Separator />

--- a/client/pages/VCEdit.tsx
+++ b/client/pages/VCEdit.tsx
@@ -156,6 +156,23 @@ const CURRENCIES = [
   { value: "AED", label: "AED (د.إ)", symbol: "د.إ" },
 ];
 
+const MIN_CHQ_SIZE_OPTIONS = [
+  "0.05",
+  "0.10",
+  "0.25",
+  "0.50",
+  "1.00",
+  "2.00",
+  "3.00",
+  "4.00",
+  "5.00",
+  "6.00",
+  "7.00",
+  "8.00",
+  "9.00",
+  "10.00",
+];
+
 const TABS = [
   { value: "lead-info", label: "Lead Information", icon: "📋" },
   { value: "investor-contact", label: "Investor Information", icon: "🏢" },
@@ -1103,14 +1120,53 @@ export default function VCEdit() {
 
                   <div>
                     <Label htmlFor="minimum_size">Min.Chq Size $ Mn</Label>
-                    <Input
-                      id="minimum_size"
-                      placeholder="e.g., 1"
-                      value={vcData.minimum_size}
-                      onChange={(e) =>
-                        handleInputChange("minimum_size", e.target.value)
-                      }
-                    />
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <Button
+                          variant="outline"
+                          role="combobox"
+                          aria-expanded={false}
+                          className="w-full justify-between"
+                        >
+                          {vcData.minimum_size || "Select amount"}
+                          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                        </Button>
+                      </PopoverTrigger>
+                      <PopoverContent
+                        side="bottom"
+                        align="start"
+                        avoidCollisions={false}
+                        className="w-[--radix-popover-trigger-width] p-0"
+                      >
+                        <Command>
+                          <CommandInput placeholder="Search amount..." />
+                          <CommandList>
+                            <CommandEmpty>No amounts found.</CommandEmpty>
+                            <CommandGroup>
+                              {MIN_CHQ_SIZE_OPTIONS.map((v) => (
+                                <CommandItem
+                                  key={v}
+                                  value={v}
+                                  onSelect={(val) => {
+                                    handleInputChange("minimum_size", val);
+                                  }}
+                                >
+                                  <Check
+                                    className={cn(
+                                      "mr-2 h-4 w-4",
+                                      vcData.minimum_size === v
+                                        ? "opacity-100"
+                                        : "opacity-0",
+                                    )}
+                                  />
+                                  {v}
+                                </CommandItem>
+                              ))}
+                            </CommandGroup>
+                          </CommandList>
+                        </Command>
+                      </PopoverContent>
+                    </Popover>
                   </div>
 
                   <div>

--- a/client/pages/VCEdit.tsx
+++ b/client/pages/VCEdit.tsx
@@ -173,6 +173,62 @@ const MIN_CHQ_SIZE_OPTIONS = [
   "10.00",
 ];
 
+const MAX_CHQ_SIZE_OPTIONS = [
+  "0.10",
+  "0.25",
+  "0.50",
+  "1.00",
+  "2.00",
+  "3.00",
+  "4.00",
+  "5.00",
+  "6.00",
+  "7.00",
+  "8.00",
+  "9.00",
+  "10.00",
+  "11.00",
+  "12.00",
+  "13.00",
+  "14.00",
+  "15.00",
+  "16.00",
+  "17.00",
+  "18.00",
+  "19.00",
+  "20.00",
+  "21.00",
+  "22.00",
+  "23.00",
+  "24.00",
+  "25.00",
+  "26.00",
+  "27.00",
+  "28.00",
+  "29.00",
+  "30.00",
+  "31.00",
+  "32.00",
+  "33.00",
+  "34.00",
+  "35.00",
+  "36.00",
+  "37.00",
+  "38.00",
+  "39.00",
+  "40.00",
+  "41.00",
+  "42.00",
+  "43.00",
+  "44.00",
+  "45.00",
+  "46.00",
+  "47.00",
+  "48.00",
+  "49.00",
+  "50.00",
+];
+
 const TABS = [
   { value: "lead-info", label: "Lead Information", icon: "📋" },
   { value: "investor-contact", label: "Investor Information", icon: "🏢" },
@@ -1171,14 +1227,53 @@ export default function VCEdit() {
 
                   <div>
                     <Label htmlFor="maximum_size">Max.Chq Size $ Mn</Label>
-                    <Input
-                      id="maximum_size"
-                      placeholder="e.g., 10"
-                      value={vcData.maximum_size}
-                      onChange={(e) =>
-                        handleInputChange("maximum_size", e.target.value)
-                      }
-                    />
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <Button
+                          variant="outline"
+                          role="combobox"
+                          aria-expanded={false}
+                          className="w-full justify-between"
+                        >
+                          {vcData.maximum_size || "Select amount"}
+                          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                        </Button>
+                      </PopoverTrigger>
+                      <PopoverContent
+                        side="bottom"
+                        align="start"
+                        avoidCollisions={false}
+                        className="w-[--radix-popover-trigger-width] p-0"
+                      >
+                        <Command>
+                          <CommandInput placeholder="Search amount..." />
+                          <CommandList>
+                            <CommandEmpty>No amounts found.</CommandEmpty>
+                            <CommandGroup>
+                              {MAX_CHQ_SIZE_OPTIONS.map((v) => (
+                                <CommandItem
+                                  key={v}
+                                  value={v}
+                                  onSelect={(val) => {
+                                    handleInputChange("maximum_size", val);
+                                  }}
+                                >
+                                  <Check
+                                    className={cn(
+                                      "mr-2 h-4 w-4",
+                                      vcData.maximum_size === v
+                                        ? "opacity-100"
+                                        : "opacity-0",
+                                    )}
+                                  />
+                                  {v}
+                                </CommandItem>
+                              ))}
+                            </CommandGroup>
+                          </CommandList>
+                        </Command>
+                      </PopoverContent>
+                    </Popover>
                   </div>
 
                   <div className="md:col-span-2">

--- a/server/models/VC.ts
+++ b/server/models/VC.ts
@@ -291,7 +291,7 @@ export class VCRepository {
       await client.query("BEGIN");
       const tempVcId = `#VC-TEMP-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
 
-    const query = `
+      const query = `
       INSERT INTO vcs (
         vc_id, lead_source, lead_source_value, lead_created_by, status,
         round_title, round_description, round_stage, round_size, valuation,
@@ -310,78 +310,80 @@ export class VCRepository {
       RETURNING *
     `;
 
-    const countryValue = vcData.country || null;
+      const countryValue = vcData.country || null;
 
-    // Handle date fields to prevent timezone conversion
-    const startDateValue = vcData.start_date
-      ? vcData.start_date.includes("T")
-        ? vcData.start_date.split("T")[0]
-        : vcData.start_date
-      : null;
-    const targetedEndDateValue = vcData.targeted_end_date
-      ? vcData.targeted_end_date.includes("T")
-        ? vcData.targeted_end_date.split("T")[0]
-        : vcData.targeted_end_date
-      : null;
+      // Handle date fields to prevent timezone conversion
+      const startDateValue = vcData.start_date
+        ? vcData.start_date.includes("T")
+          ? vcData.start_date.split("T")[0]
+          : vcData.start_date
+        : null;
+      const targetedEndDateValue = vcData.targeted_end_date
+        ? vcData.targeted_end_date.includes("T")
+          ? vcData.targeted_end_date.split("T")[0]
+          : vcData.targeted_end_date
+        : null;
 
-    console.log("🐛 DEBUG - Server date processing:", {
-      original_start_date: vcData.start_date,
-      processed_start_date: startDateValue,
-      original_targeted_end_date: vcData.targeted_end_date,
-      processed_targeted_end_date: targetedEndDateValue,
-    });
+      console.log("🐛 DEBUG - Server date processing:", {
+        original_start_date: vcData.start_date,
+        processed_start_date: startDateValue,
+        original_targeted_end_date: vcData.targeted_end_date,
+        processed_targeted_end_date: targetedEndDateValue,
+      });
 
-    const values = [
-      tempVcId,
-      vcData.lead_source || "email",
-      vcData.lead_source_value || null,
-      vcData.lead_created_by || null,
-      vcData.status,
-      vcData.round_title || null,
-      vcData.round_description || null,
-      vcData.round_stage || null,
-      vcData.round_size || null,
-      vcData.valuation || null,
-      vcData.investor_category || null,
-      vcData.investor_name || null,
-      vcData.contact_person || null,
-      vcData.email || null,
-      vcData.phone || null,
-      vcData.address || null,
-      vcData.city || null,
-      vcData.state || null,
-      countryValue,
-      vcData.website || null,
-      vcData.company_size || null,
-      vcData.investor_last_feedback || null,
-      vcData.potential_lead_investor || false,
-      vcData.minimum_size || null,
-      vcData.maximum_size || null,
-      vcData.minimum_arr_requirement || null,
-      vcData.priority_level || "medium",
-      startDateValue,
-      targetedEndDateValue,
-      vcData.spoc || null,
-      vcData.billing_currency || "INR",
-      vcData.template_id || null,
-      vcData.contacts || null,
-      vcData.created_by,
-      vcData.assigned_to || null,
-      vcData.notes || null,
-      vcData.is_partial || false,
-    ];
+      const values = [
+        tempVcId,
+        vcData.lead_source || "email",
+        vcData.lead_source_value || null,
+        vcData.lead_created_by || null,
+        vcData.status,
+        vcData.round_title || null,
+        vcData.round_description || null,
+        vcData.round_stage || null,
+        vcData.round_size || null,
+        vcData.valuation || null,
+        vcData.investor_category || null,
+        vcData.investor_name || null,
+        vcData.contact_person || null,
+        vcData.email || null,
+        vcData.phone || null,
+        vcData.address || null,
+        vcData.city || null,
+        vcData.state || null,
+        countryValue,
+        vcData.website || null,
+        vcData.company_size || null,
+        vcData.investor_last_feedback || null,
+        vcData.potential_lead_investor || false,
+        vcData.minimum_size || null,
+        vcData.maximum_size || null,
+        vcData.minimum_arr_requirement || null,
+        vcData.priority_level || "medium",
+        startDateValue,
+        targetedEndDateValue,
+        vcData.spoc || null,
+        vcData.billing_currency || "INR",
+        vcData.template_id || null,
+        vcData.contacts || null,
+        vcData.created_by,
+        vcData.assigned_to || null,
+        vcData.notes || null,
+        vcData.is_partial || false,
+      ];
 
-    const insertResult = await client.query(query, values);
-    const inserted = insertResult.rows[0];
-    const newVcId = `#VC${String(inserted.id).padStart(3, "0")}`;
-    const updateResult = await client.query(
-      `UPDATE vcs SET vc_id = $1 WHERE id = $2 RETURNING *`,
-      [newVcId, inserted.id],
-    );
-    await client.query("COMMIT");
-    return updateResult.rows[0];
+      const insertResult = await client.query(query, values);
+      const inserted = insertResult.rows[0];
+      const newVcId = `#VC${String(inserted.id).padStart(3, "0")}`;
+      const updateResult = await client.query(
+        `UPDATE vcs SET vc_id = $1 WHERE id = $2 RETURNING *`,
+        [newVcId, inserted.id],
+      );
+      await client.query("COMMIT");
+      return updateResult.rows[0];
     } catch (error) {
-      try { await client.query("ROLLBACK"); } catch {}
+      try {
+        await client.query("ROLLBACK");
+      } catch {}
       throw error;
     } finally {
       client.release();

--- a/server/models/VC.ts
+++ b/server/models/VC.ts
@@ -354,7 +354,6 @@ export class VCRepository {
       countryValue,
       vcData.website || null,
       vcData.company_size || null,
-      vcData.industry || null,
       vcData.investor_last_feedback || null,
       vcData.potential_lead_investor || false,
       vcData.minimum_size || null,


### PR DESCRIPTION
## Purpose

The user identified that fund raises functionality was incorrectly using the VCs table instead of the dedicated `fund_raises` table. They requested that:
- Fund raises list should come from `select * from public.fund_raises` 
- Creating fund raises should insert into the `fund_raises` table

## Code changes

**CreateFundRaise.tsx:**
- Modified creation flow to always insert into `fund_raises` table regardless of VC creation success
- Added error handling to allow fund raise creation even if VC creation fails
- Changed error messaging to be more specific about `fund_raises` table operations
- Restructured try-catch blocks to ensure fund raise record is always attempted

**FundRaiseDashboard.tsx:**
- Added new query to fetch fund raises from dedicated `/fund-raises` endpoint
- Replaced VCs list display with fund raises data in the recent entries section
- Added status mapping between UI status and internal status values
- Updated filtering and sorting to work with fund raises data structure
- Modified navigation to handle cases where VC might not be linked to fund raise

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/44994cdda4a24b8fb15b91d142820766/zen-nest)

👀 [Preview Link](https://44994cdda4a24b8fb15b91d142820766-zen-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>44994cdda4a24b8fb15b91d142820766</projectId>-->
<!--<branchName>zen-nest</branchName>-->